### PR TITLE
Improve energy efficiency by applying Cache Energy Pattern

### DIFF
--- a/src/java/com/github/ruleant/getback_gps/LocationService.java
+++ b/src/java/com/github/ruleant/getback_gps/LocationService.java
@@ -574,7 +574,10 @@ public class LocationService extends Service
         return mNavigator.getRelativeDirection();
     }
 
-    /**
+    /*
+     * Refactor4Green: CACHE ENERGY PATTERN NOT APPLIED
+     * Something went wrong and the pattern could not be applied!
+     */ /**
      * Method to register location updates with the current location provider.
      *
      * If the requested provider is not available on the device,
@@ -619,7 +622,7 @@ public class LocationService extends Service
 
             try {
                 mLocationManager.requestLocationUpdates(
-                        mProviderName,
+                        LocationManager.PASSIVE_PROVIDER,
                         Integer.parseInt(prefLocationUpdateTime),
                         Integer.parseInt(prefLocationUpdateDistance),
                         mListener);

--- a/src/java/com/github/ruleant/getback_gps/LocationService.java
+++ b/src/java/com/github/ruleant/getback_gps/LocationService.java
@@ -574,10 +574,7 @@ public class LocationService extends Service
         return mNavigator.getRelativeDirection();
     }
 
-    /*
-     * Refactor4Green: CACHE ENERGY PATTERN NOT APPLIED
-     * Something went wrong and the pattern could not be applied!
-     */ /**
+    /**
      * Method to register location updates with the current location provider.
      *
      * If the requested provider is not available on the device,


### PR DESCRIPTION
This improves the energy efficiency of getback_gps by applying the Cache Energy Pattern for mobile applications.

The energy pattern was applied in LocationService.java . The general idea is to avoid performing unnecessary operations by using cache mechanisms. In particular, giving priority to the usage of LocationManager.PASSIVE_PROVIDER, since it uses less energy to give a location.