### PR TITLE
Data loss aften an orientation change. #195

### DIFF
--- a/src/java/com/github/ruleant/getback_gps/AbstractGetBackGpsActivity.java
+++ b/src/java/com/github/ruleant/getback_gps/AbstractGetBackGpsActivity.java
@@ -251,8 +251,8 @@ abstract class AbstractGetBackGpsActivity extends Activity
                 STORE_LOCATION_DIALOG_STATE_PREFIX, savedInstanceState);
         Bundle enterLocationDialogState = StateBundleHelper.filterStringValuesForPrefix(
                 ENTER_LOCATION_DIALOG_STATE_PREFIX, savedInstanceState);
-        Bundle renameDestinationDialogState = StateBundleHelper.filterStringValuesForPrefix
-                (RENAME_DESTINATION_DIALOG_STATE_PREFIX, savedInstanceState);
+        Bundle renameDestinationDialogState = StateBundleHelper.filterStringValuesForPrefix(
+                RENAME_DESTINATION_DIALOG_STATE_PREFIX, savedInstanceState);
 
         if (!storeLocationDialogState.isEmpty()) {
             dialogState.putAll(storeLocationDialogState);

--- a/src/java/com/github/ruleant/getback_gps/AbstractGetBackGpsActivity.java
+++ b/src/java/com/github/ruleant/getback_gps/AbstractGetBackGpsActivity.java
@@ -262,19 +262,23 @@ abstract class AbstractGetBackGpsActivity extends Activity
                 = (EditText) dialogView.findViewById(R.id.location_name);
         if(locationNameUnderEditing != null) { // indicates an ongoing editing process
             etLocationName.setText(locationNameUnderEditing);
+        } else {
+            locationNameUnderEditing = "";
         }
         etLocationName.addTextChangedListener(new TextWatcher() {
             @Override
             public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+                // only the final text is stored
             }
 
             @Override
             public void onTextChanged(CharSequence s, int start, int before, int count) {
-                locationNameUnderEditing = etLocationName.getText().toString();
+                // only the final text is stored
             }
 
             @Override
             public void afterTextChanged(Editable s) {
+                locationNameUnderEditing = s.toString();
             }
         });
 

--- a/src/java/com/github/ruleant/getback_gps/AbstractGetBackGpsActivity.java
+++ b/src/java/com/github/ruleant/getback_gps/AbstractGetBackGpsActivity.java
@@ -34,6 +34,8 @@ import android.content.res.Resources;
 import android.graphics.Point;
 import android.os.Bundle;
 import android.os.IBinder;
+import android.text.Editable;
+import android.text.TextWatcher;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -152,6 +154,12 @@ abstract class AbstractGetBackGpsActivity extends Activity
      */
     private Crouton crDestinationReached;
 
+    /**
+     * Used to store the (partial) location name that is currently edited in the location dialog.
+     * In case of no location dialog open it is 'null'.
+     */
+    protected String locationNameUnderEditing = null;
+
     @Override
     public boolean onCreateOptionsMenu(final Menu menu) {
         // Inflate the menu;
@@ -252,6 +260,23 @@ abstract class AbstractGetBackGpsActivity extends Activity
         // Get the EditText object containing the location name
         final EditText etLocationName
                 = (EditText) dialogView.findViewById(R.id.location_name);
+        if(locationNameUnderEditing != null) { // indicates an ongoing editing process
+            etLocationName.setText(locationNameUnderEditing);
+        }
+        etLocationName.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+            }
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+                locationNameUnderEditing = etLocationName.getText().toString();
+            }
+
+            @Override
+            public void afterTextChanged(Editable s) {
+            }
+        });
 
         // Set the layout for the dialog
         builder.setView(dialogView)
@@ -263,6 +288,7 @@ abstract class AbstractGetBackGpsActivity extends Activity
                                 if (etLocationName != null) {
                                     String locationName
                                         = etLocationName.getText().toString();
+                                    locationNameUnderEditing = null;
 
                                     // store current location
                                     // and refresh display
@@ -278,11 +304,19 @@ abstract class AbstractGetBackGpsActivity extends Activity
                         new DialogInterface.OnClickListener() {
                             public void onClick(final DialogInterface dialog,
                                                 final int id) {
+                                locationNameUnderEditing = null;
                                 // User cancelled the dialog
                             }
                         });
         // Create the AlertDialog object and display it
-        builder.create().show();
+        AlertDialog dialog = builder.create();
+        dialog.setOnDismissListener(new DialogInterface.OnDismissListener() {
+            @Override
+            public void onDismiss(DialogInterface dialog) {
+                locationNameUnderEditing = null;
+            }
+        });
+        dialog.show();
     }
 
     /**

--- a/src/java/com/github/ruleant/getback_gps/AbstractGetBackGpsActivity.java
+++ b/src/java/com/github/ruleant/getback_gps/AbstractGetBackGpsActivity.java
@@ -3,6 +3,7 @@
  *
  * Copyright (C) 2012-2021 Dieter Adriaenssens
  * Copyright (C) 2019 Timotheos Constambeys
+ * Copyright (C) 2022 Jan Scheible
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/java/com/github/ruleant/getback_gps/AbstractGetBackGpsActivity.java
+++ b/src/java/com/github/ruleant/getback_gps/AbstractGetBackGpsActivity.java
@@ -24,9 +24,7 @@ package com.github.ruleant.getback_gps;
 
 import android.Manifest;
 import android.app.Activity;
-import android.app.AlertDialog;
 import android.app.Dialog;
-import android.app.DialogFragment;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.DialogInterface;

--- a/src/java/com/github/ruleant/getback_gps/MainActivity.java
+++ b/src/java/com/github/ruleant/getback_gps/MainActivity.java
@@ -31,8 +31,6 @@ import android.view.View;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
-import androidx.annotation.NonNull;
-
 import com.github.ruleant.getback_gps.lib.AriadneLocation;
 import com.github.ruleant.getback_gps.lib.CardinalDirection;
 import com.github.ruleant.getback_gps.lib.DebugLevel;
@@ -46,8 +44,6 @@ import com.github.ruleant.getback_gps.lib.Navigator;
  */
 public class MainActivity extends AbstractGetBackGpsActivity
         implements View.OnClickListener {
-    private static final String LOCATION_NAME_UNDER_EDITING_BUNDLE_KEY = "locationNameUnderEditing";
-
     /**
      * Maximum length when displaying destination name (Portrait orientation).
      */
@@ -73,25 +69,6 @@ public class MainActivity extends AbstractGetBackGpsActivity
         TextView tvDestinationName
                 = (TextView) findViewById(R.id.textView_toDestName);
         tvDestinationName.setOnClickListener(this);
-    }
-
-    @Override
-    protected void onSaveInstanceState(@NonNull Bundle outState) {
-        super.onSaveInstanceState(outState);
-        outState.putString(LOCATION_NAME_UNDER_EDITING_BUNDLE_KEY, locationNameUnderEditing);
-    }
-
-    @Override
-    protected void onRestoreInstanceState(@NonNull Bundle savedInstanceState) {
-        super.onRestoreInstanceState(savedInstanceState);
-        locationNameUnderEditing = savedInstanceState
-                .getString(LOCATION_NAME_UNDER_EDITING_BUNDLE_KEY);
-
-        // as soon as there is a (partial) location name available the location dialog was open
-        // and an editing process was ongoing
-        if(locationNameUnderEditing != null) {
-            storeLocation();
-        }
     }
 
     @Override

--- a/src/java/com/github/ruleant/getback_gps/MainActivity.java
+++ b/src/java/com/github/ruleant/getback_gps/MainActivity.java
@@ -31,6 +31,8 @@ import android.view.View;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+
 import com.github.ruleant.getback_gps.lib.AriadneLocation;
 import com.github.ruleant.getback_gps.lib.CardinalDirection;
 import com.github.ruleant.getback_gps.lib.DebugLevel;
@@ -69,6 +71,24 @@ public class MainActivity extends AbstractGetBackGpsActivity
         TextView tvDestinationName
                 = (TextView) findViewById(R.id.textView_toDestName);
         tvDestinationName.setOnClickListener(this);
+    }
+
+    @Override
+    protected void onSaveInstanceState(@NonNull Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putString("locationNameUnderEditing", locationNameUnderEditing);
+    }
+
+    @Override
+    protected void onRestoreInstanceState(@NonNull Bundle savedInstanceState) {
+        super.onRestoreInstanceState(savedInstanceState);
+        locationNameUnderEditing = savedInstanceState.getString("locationNameUnderEditing");
+
+        // as soon as there is a (partial) location name available the location dialog was open
+        // and an editing process was ongoing
+        if(locationNameUnderEditing != null) {
+            storeLocation();
+        }
     }
 
     @Override

--- a/src/java/com/github/ruleant/getback_gps/MainActivity.java
+++ b/src/java/com/github/ruleant/getback_gps/MainActivity.java
@@ -46,6 +46,8 @@ import com.github.ruleant.getback_gps.lib.Navigator;
  */
 public class MainActivity extends AbstractGetBackGpsActivity
         implements View.OnClickListener {
+    private static final String LOCATION_NAME_UNDER_EDITING_BUNDLE_KEY = "locationNameUnderEditing";
+
     /**
      * Maximum length when displaying destination name (Portrait orientation).
      */
@@ -76,13 +78,14 @@ public class MainActivity extends AbstractGetBackGpsActivity
     @Override
     protected void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
-        outState.putString("locationNameUnderEditing", locationNameUnderEditing);
+        outState.putString(LOCATION_NAME_UNDER_EDITING_BUNDLE_KEY, locationNameUnderEditing);
     }
 
     @Override
     protected void onRestoreInstanceState(@NonNull Bundle savedInstanceState) {
         super.onRestoreInstanceState(savedInstanceState);
-        locationNameUnderEditing = savedInstanceState.getString("locationNameUnderEditing");
+        locationNameUnderEditing = savedInstanceState
+                .getString(LOCATION_NAME_UNDER_EDITING_BUNDLE_KEY);
 
         // as soon as there is a (partial) location name available the location dialog was open
         // and an editing process was ongoing

--- a/src/java/com/github/ruleant/getback_gps/StateBundleHelper.java
+++ b/src/java/com/github/ruleant/getback_gps/StateBundleHelper.java
@@ -1,0 +1,31 @@
+package com.github.ruleant.getback_gps;
+
+import android.os.Bundle;
+
+import java.util.function.Supplier;
+
+class StateBundleHelper {
+
+    /**
+     * @param prefix is used for identifying relevant keys
+     * @param state is the input state
+     * @return @return New bundle with all non-null String entries with a key that have the prefix.
+     */
+    static Bundle filterStringValuesForPrefix(String prefix, Bundle state) {
+        return filterStringValuesForPrefix(prefix, state, new Bundle());
+    }
+
+    static Bundle filterStringValuesForPrefix(String prefix, Bundle state, Bundle result) {
+        for (final String stateKey : state.keySet()) {
+            if (stateKey.startsWith(prefix)) {
+                Object stateValue = state.get(stateKey);
+
+                if(stateValue instanceof String) {
+                    result.putString(stateKey, stateValue.toString());
+                }
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/java/com/github/ruleant/getback_gps/StateBundleHelper.java
+++ b/src/java/com/github/ruleant/getback_gps/StateBundleHelper.java
@@ -2,8 +2,6 @@ package com.github.ruleant.getback_gps;
 
 import android.os.Bundle;
 
-import java.util.function.Supplier;
-
 class StateBundleHelper {
 
     /**

--- a/src/java/com/github/ruleant/getback_gps/StateBundleHelper.java
+++ b/src/java/com/github/ruleant/getback_gps/StateBundleHelper.java
@@ -1,3 +1,24 @@
+/**
+ * StateBundleHelper
+ *
+ * Copyright (C) 2022 Jan Scheible
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @package com.github.ruleant.getback_gps
+ * @author Jan Scheible
+ */
 package com.github.ruleant.getback_gps;
 
 import android.os.Bundle;
@@ -5,14 +26,24 @@ import android.os.Bundle;
 class StateBundleHelper {
 
     /**
+     * Returns a new bundle with all non-null String entries with a key that have the prefix.
+     *
      * @param prefix is used for identifying relevant keys
      * @param state is the input state
-     * @return @return New bundle with all non-null String entries with a key that have the prefix.
+     * @return a new, filtered bundle
      */
     static Bundle filterStringValuesForPrefix(String prefix, Bundle state) {
         return filterStringValuesForPrefix(prefix, state, new Bundle());
     }
 
+    /**
+     * Returns a new bundle with all non-null String entries with a key that have the prefix.
+     *
+     * @param prefix is used for identifying relevant keys
+     * @param state is the input state
+     * @param result target bundle
+     * @return the target bundle with the filtered values added
+     */
     static Bundle filterStringValuesForPrefix(String prefix, Bundle state, Bundle result) {
         for (final String stateKey : state.keySet()) {
             if (stateKey.startsWith(prefix)) {

--- a/src/java/com/github/ruleant/getback_gps/StateTrackingDialogBuilder.java
+++ b/src/java/com/github/ruleant/getback_gps/StateTrackingDialogBuilder.java
@@ -62,10 +62,12 @@ class StateTrackingDialogBuilder {
         textView.addTextChangedListener(new TextWatcher() {
             @Override
             public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+                // only the final text is stored
             }
 
             @Override
             public void onTextChanged(CharSequence s, int start, int before, int count) {
+                // only the final text is stored
             }
 
             @Override

--- a/src/java/com/github/ruleant/getback_gps/StateTrackingDialogBuilder.java
+++ b/src/java/com/github/ruleant/getback_gps/StateTrackingDialogBuilder.java
@@ -1,3 +1,24 @@
+/**
+ * StateTrackingDialogBuilder
+ *
+ * Copyright (C) 2022 Jan Scheible
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @package com.github.ruleant.getback_gps
+ * @author Jan Scheible
+ */
 package com.github.ruleant.getback_gps;
 
 import android.app.AlertDialog;
@@ -24,7 +45,9 @@ class StateTrackingDialogBuilder {
     private final Bundle state;
 
     /**
-     * @param context is used for{@code AlertDialog.Builder}
+     * Create a new dialog builder with state tracking enabled.
+     *
+     * @param context is used for {@code AlertDialog.Builder}
      * @param statePrefix as prefix for all keys of the state
      * @param state is used to store the {@code TextView} texts
      */
@@ -34,6 +57,13 @@ class StateTrackingDialogBuilder {
         this.state = state;
     }
 
+    /**
+     * Calls {@link AlertDialog.Builder#setView(View)} under the hood and tracks state of all
+     * {@code TextView} children.
+
+     * @param view the view of the dialog
+     * @return builder instance for chaining
+     */
     StateTrackingDialogBuilder setView(View view) {
         delegate.setView(view);
 
@@ -51,12 +81,19 @@ class StateTrackingDialogBuilder {
         return this;
     }
 
+    /**
+     * Tracks state of the {@code textView}. That includes initial state setting as well change
+     * detection in case of UI changes.
+     *
+     * @param textView to track state
+     * @param stateId key to use for the state bundle that was passed in the constructor
+     */
     private void trackState(TextView textView, String stateId) {
         String stateTextValue = state.getString(stateId);
         if (stateTextValue != null) {
             textView.setText(stateTextValue);
         } else {
-            state.putString(stateId, "");
+            state.putString(stateId, textView.getText().toString());
         }
 
         textView.addTextChangedListener(new TextWatcher() {
@@ -77,17 +114,39 @@ class StateTrackingDialogBuilder {
         });
     }
 
+    /**
+     * Calls {@link AlertDialog.Builder#setTitle(int)} under the hood.
+     *
+     * @param titleId the title of the dialog
+     * @return builder instance for chaining
+     */
     StateTrackingDialogBuilder setTitle(@StringRes int titleId) {
         delegate.setTitle(titleId);
         return this;
     }
 
+    /**
+     * Calls {@link AlertDialog.Builder#setPositiveButton(int, DialogInterface.OnClickListener)}
+     * under the hood.
+     *
+     * @param textId the text of the button
+     * @param listener the on click listener of the button
+     * @return builder instance for chaining
+     */
     StateTrackingDialogBuilder setPositiveButton(@StringRes int textId,
                                                  final DialogInterface.OnClickListener listener) {
         delegate.setPositiveButton(textId, listener);
         return this;
     }
 
+    /**
+     * Calls {@link AlertDialog.Builder#setNegativeButton(int, DialogInterface.OnClickListener)}
+     * under the hood.
+     *
+     * @param textId the text of the button
+     * @param listener the on click listener of the button
+     * @return builder instance for chaining
+     */
     StateTrackingDialogBuilder setNegativeButton(@StringRes int textId,
                                                  final DialogInterface.OnClickListener listener) {
         delegate.setNegativeButton(textId, (dialog, which) -> {
@@ -98,6 +157,11 @@ class StateTrackingDialogBuilder {
         return this;
     }
 
+    /**
+     * Calls {@link AlertDialog.Builder#create()} under the hood.
+     *
+     * @return builder instance for chaining
+     */
     AlertDialog create() {
         AlertDialog dialog = delegate.create();
         dialog.setOnDismissListener(listenerDialog -> state.clear());

--- a/src/java/com/github/ruleant/getback_gps/StateTrackingDialogBuilder.java
+++ b/src/java/com/github/ruleant/getback_gps/StateTrackingDialogBuilder.java
@@ -1,0 +1,105 @@
+package com.github.ruleant.getback_gps;
+
+import android.app.AlertDialog;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.os.Bundle;
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import androidx.annotation.StringRes;
+
+/**
+ * Custom dialog builder that uses {@code AlertDialog.Builder} under the hood. The text values
+ * of all {@code TextView} views are automatically synced with the state.
+ * Also standard use cases as the negative button or dialog dismiss are covered and clear the state.
+ */
+class StateTrackingDialogBuilder {
+
+    private final AlertDialog.Builder delegate;
+    private final String statePrefix;
+    private final Bundle state;
+
+    /**
+     * @param context is used for{@code AlertDialog.Builder}
+     * @param statePrefix as prefix for all keys of the state
+     * @param state is used to store the {@code TextView} texts
+     */
+    StateTrackingDialogBuilder(Context context, String statePrefix, Bundle state) {
+        delegate = new AlertDialog.Builder(context);
+        this.statePrefix = statePrefix;
+        this.state = state;
+    }
+
+    StateTrackingDialogBuilder setView(View view) {
+        delegate.setView(view);
+
+        if (view instanceof ViewGroup) {
+            ViewGroup viewGroup = (ViewGroup) view;
+            for (int i = 0; i < viewGroup.getChildCount(); i++) {
+                View child = viewGroup.getChildAt(i);
+
+                if (child instanceof TextView) {
+                    trackState((TextView) child, statePrefix + child.getId());
+                }
+            }
+        }
+
+        return this;
+    }
+
+    private void trackState(TextView textView, String stateId) {
+        String stateTextValue = state.getString(stateId);
+        if (stateTextValue != null) {
+            textView.setText(stateTextValue);
+        } else {
+            state.putString(stateId, "");
+        }
+
+        textView.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+            }
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+            }
+
+            @Override
+            public void afterTextChanged(Editable s) {
+                state.putString(stateId, textView.getText().toString());
+            }
+        });
+    }
+
+    StateTrackingDialogBuilder setTitle(@StringRes int titleId) {
+        delegate.setTitle(titleId);
+        return this;
+    }
+
+    StateTrackingDialogBuilder setPositiveButton(@StringRes int textId,
+                                                 final DialogInterface.OnClickListener listener) {
+        delegate.setPositiveButton(textId, listener);
+        return this;
+    }
+
+    StateTrackingDialogBuilder setNegativeButton(@StringRes int textId,
+                                                 final DialogInterface.OnClickListener listener) {
+        delegate.setNegativeButton(textId, (dialog, which) -> {
+            state.clear();
+            listener.onClick(dialog, which);
+        });
+
+        return this;
+    }
+
+    AlertDialog create() {
+        AlertDialog dialog = delegate.create();
+        dialog.setOnDismissListener(listenerDialog -> state.clear());
+
+        return dialog;
+    }
+}

--- a/src/test/java/com/github/ruleant/getback_gps/StateBundleHelperTest.java
+++ b/src/test/java/com/github/ruleant/getback_gps/StateBundleHelperTest.java
@@ -1,3 +1,24 @@
+/**
+ * StateBundleHelperTest
+ *
+ * Copyright (C) 2022 Jan Scheible
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @package com.github.ruleant.getback_gps
+ * @author Jan Scheible
+ */
 package com.github.ruleant.getback_gps;
 
 import android.os.Bundle;
@@ -29,6 +50,8 @@ public class StateBundleHelperTest {
 
     /**
      * Creates a mocked {@code Bundle} that is backed by a {@code HashMap} instance.
+     *
+     * @return mocked bundle
      */
     private static Bundle createBundleMock() {
         Map<String, Object> storage = new HashMap<>();

--- a/src/test/java/com/github/ruleant/getback_gps/StateBundleHelperTest.java
+++ b/src/test/java/com/github/ruleant/getback_gps/StateBundleHelperTest.java
@@ -1,0 +1,53 @@
+package com.github.ruleant.getback_gps;
+
+import android.os.Bundle;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+public class StateBundleHelperTest {
+
+    @Test
+    public void testFilter() {
+        Bundle state = createBundleMock();
+        state.putString("prefix-null", null);
+        state.putString("abc-key", "xyz");
+        state.putInt("prefix-int", 42);
+        state.putString("prefix-string", ":-)");
+
+        Bundle filtered = StateBundleHelper.filterStringValuesForPrefix(
+                "prefix", state, createBundleMock());
+        Assertions.assertEquals(new HashSet<>(Arrays.asList("prefix-string")), filtered.keySet());
+    }
+
+    /**
+     * Creates a mocked {@code Bundle} that is backed by a {@code HashMap} instance.
+     */
+    private static Bundle createBundleMock() {
+        Map<String, Object> storage = new HashMap<>();
+
+        Answer<Void> storeSideEffect = invocation -> {
+            String key = invocation.getArgument(0, String.class);
+            Object value = invocation.getArgument(1, Object.class);
+            storage.put(key, value);
+            return null;
+        };
+
+        Bundle bundle = Mockito.mock(Bundle.class);
+
+        Mockito.doAnswer(storeSideEffect).when(bundle).putString(Mockito.anyString(), Mockito.anyString());
+        Mockito.doAnswer(storeSideEffect).when(bundle).putInt(Mockito.anyString(), Mockito.anyInt());
+        Mockito.doAnswer(invocation -> storage.keySet()).when(bundle).keySet();
+        Mockito.doAnswer(invocation -> storage.get(invocation.getArgument(0, String.class)))
+                .when(bundle).get(Mockito.anyString());
+
+        return bundle;
+    }
+}


### PR DESCRIPTION
After having a look at https://github.com/ruleant/getback_gps/pull/196 and reading the documentation referenced in https://github.com/ruleant/getback_gps/pull/196#issuecomment-1016891111 I came to the conclusion that the view state has to be persisted in the `onSaveInstanceState(Bundle)` method. The `onRestoreInstanceState(Bundle)` then needs to check if an ongoing location editing process was persisted and re-open the dialog accordingly.

**Disclaimer**: I have no real Android development experience, I was just [nerd sniped](https://xkcd.com/356/) by the question what the best way to fix that bug might be.

Some open questions:
- [code-organization] Is the `MainActivity` class the right place for  the `onSaveInstanceState(Bundle)` and the `onRestoreInstanceState(Bundle)` implementations or should they go to `AbstractGetBackGpsActivity` class?
- [approach] Is a member variable (`locationNameUnderEditing`) really the best way to track and store the (transient) state? All that event handler do not look that pretty. The case with just closing the dialog by touching somewhere outside the dialog almost slipped through.