### PR TITLE
proof of concept for #153 "Treasure hunt mode"

### DIFF
--- a/res/menu/common.xml
+++ b/res/menu/common.xml
@@ -27,6 +27,11 @@
         android:icon="@drawable/ic_action_refresh"
         android:title="@string/refresh" />
     <item
+        android:id="@+id/menu_hunt"
+        android:orderInCategory="80"
+        android:showAsAction="never"
+        android:title="Treasure Hunt" />
+    <item
         android:id="@+id/menu_about"
         android:orderInCategory="100"
         android:showAsAction="never"

--- a/src/java/com/github/ruleant/getback_gps/AbstractGetBackGpsActivity.java
+++ b/src/java/com/github/ruleant/getback_gps/AbstractGetBackGpsActivity.java
@@ -45,11 +45,17 @@ import android.widget.Toast;
 import com.github.ruleant.getback_gps.LocationService.LocationBinder;
 import com.github.ruleant.getback_gps.lib.CardinalDirection;
 import com.github.ruleant.getback_gps.lib.FormatUtils;
+import com.github.ruleant.getback_gps.lib.HuntDestination;
 import com.github.ruleant.getback_gps.lib.Navigator;
 import com.github.ruleant.getback_gps.lib.Tools;
 
 import androidx.annotation.NonNull;
 import androidx.core.app.ActivityCompat;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import de.keyboardsurfer.android.widget.crouton.Configuration;
 import de.keyboardsurfer.android.widget.crouton.Crouton;
 import de.keyboardsurfer.android.widget.crouton.Style;
@@ -126,6 +132,23 @@ abstract class AbstractGetBackGpsActivity extends Activity
      * Crouton status 'Inaccurate direction'.
      */
     private static final short CROUTON_STATUS_DESTINATION_REACHED = 5;
+
+    /**
+     * Hardcoded treasure hunt route for now.
+     */
+    private static final List<HuntDestination> HUNT_DESTINATIONS = Arrays.asList(
+            new HuntDestination("Start", 48.39871654313094, 9.984295534933059),
+            new HuntDestination("Point 1", 48.398219371786716, 9.98727274186329),
+            new HuntDestination("Point 2", 48.39983665835421, 9.987227632667379),
+            new HuntDestination("Point 3", 48.39921969954438, 9.989753747638483),
+            new HuntDestination("Point 4", 48.39827328216732, 9.990249948793522),
+            new HuntDestination("Treasure", 48.39860872325201, 9.991341591334608));
+
+    /**
+     * The current ongoing treasure hunt (lower index destiantions first).
+     * List is empty if there is no treasure hunt going on at all.
+     */
+    private final List<HuntDestination> huntDestinations = new ArrayList<>();
 
     /**
      * Location permission required crouton.
@@ -264,6 +287,7 @@ abstract class AbstractGetBackGpsActivity extends Activity
                                     String locationName
                                         = etLocationName.getText().toString();
 
+                                    huntDestinations.clear();
                                     // store current location
                                     // and refresh display
                                     if (mBound) {
@@ -285,12 +309,22 @@ abstract class AbstractGetBackGpsActivity extends Activity
         builder.create().show();
     }
 
+    protected void nextHuntDestination() {
+        if(!huntDestinations.isEmpty()) {
+            HuntDestination next = huntDestinations.get(0);
+            huntDestinations.remove(0);
+
+            if (mBound) {
+                mService.storeLocation(next.getName(), next.getLatitude(), next.getLongitude());
+            }
+        }
+    }
+
     /**
      * Called when the user clicks the Enter Location menu item.
      * It displays a dialog, where the user enters a gps location.
      */
     public final void enterLocation() {
-
         // Use the Builder class for convenient dialog construction,
         // based on the example on
         // https://developer.android.com/guide/topics/ui/dialogs.html
@@ -344,6 +378,7 @@ abstract class AbstractGetBackGpsActivity extends Activity
                                         return;
                                     }
 
+                                    huntDestinations.clear();
                                     // store current location
                                     // and refresh display
                                     if (mBound) {
@@ -516,6 +551,13 @@ abstract class AbstractGetBackGpsActivity extends Activity
             return true;
         } else if (itemId == R.id.menu_refresh) {
             refresh(item);
+            return true;
+        } else if (itemId == R.id.menu_hunt) {
+            // start/restart the hunt with the hardcoded destinations
+            huntDestinations.clear();
+            huntDestinations.addAll(HUNT_DESTINATIONS);
+
+            nextHuntDestination();
             return true;
         } else {
             return super.onOptionsItemSelected(item);

--- a/src/java/com/github/ruleant/getback_gps/MainActivity.java
+++ b/src/java/com/github/ruleant/getback_gps/MainActivity.java
@@ -59,6 +59,15 @@ public class MainActivity extends AbstractGetBackGpsActivity
      */
     private static final String SHORTENER = "(...)";
 
+    /**
+     * As soon as the dwell time exceeds the threshold the next hunt destination is set.
+     */
+    private static final int HUNT_DESTINATION_DWELL_TIME_THRESHOLD = 5000;
+
+    /**
+     * Timestamp of reaching the destination.
+     */
+    private Long reachedDestinationTimestamp = null;
 
     @Override
     protected final void onCreate(final Bundle savedInstanceState) {
@@ -183,12 +192,23 @@ public class MainActivity extends AbstractGetBackGpsActivity
         Boolean displayToDest = false;
 
         if (destination == null) {
+            reachedDestinationTimestamp = null;
             toDestinationMessage
                     = res.getString(R.string.no_destination);
         } else if (navigator.isDestinationReached()) {
+            if(reachedDestinationTimestamp == null) {
+                reachedDestinationTimestamp = System.currentTimeMillis();
+            } else {
+                long destinationDwellTime = System.currentTimeMillis() - reachedDestinationTimestamp;
+
+                if(destinationDwellTime > HUNT_DESTINATION_DWELL_TIME_THRESHOLD) {
+                    nextHuntDestination();
+                }
+            }
             toDestinationMessage
                     = res.getString(R.string.destination_reached);
         } else {
+            reachedDestinationTimestamp = null;
             displayToDest = true;
 
             // Set destination name

--- a/src/java/com/github/ruleant/getback_gps/lib/HuntDestination.java
+++ b/src/java/com/github/ruleant/getback_gps/lib/HuntDestination.java
@@ -1,0 +1,26 @@
+package com.github.ruleant.getback_gps.lib;
+
+public class HuntDestination {
+
+    private final String name;
+    private final double latitude;
+    private final double longitude;
+
+    public HuntDestination(final String name, final double latitude, final double longitude) {
+        this.name = name;
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public double getLatitude() {
+        return latitude;
+    }
+
+    public double getLongitude() {
+        return longitude;
+    }
+}


### PR DESCRIPTION
I was searching for a simple app to do a treasure hunt. I found this issue in GetBack GPS and wanted to give it a try. :-)
Perhaps this is possible way to go to add such a feature to the codebase.

- re-uses as much as possible of the destination reached logic and the presentation in the UI
- `MainActivity`
  - as soon as the destination is reached and a certain dwell time (currently 5s) elapsed the next hunt destination is set
- `AbstractGetBackGpsActivity`
  - `HUNT_DESTINATIONS` is a hard-coded list of hunt destinations
    - **TODO** provide a UI for the hunt destinations (that would better fit to #154 "Multiple consecutive destinations" because the user sees the locations)
      - alternatively fetch them from some server to hide the from the user, but that would required Internet access permissions
  - `huntDestinations` holds the remaining hunt destinations (or non at all if not in treasure hunt mode)
  - a new menu item to start treasure hunt (hard-coded English menu text for now)